### PR TITLE
Update protocol version

### DIFF
--- a/src/network/constants.rs
+++ b/src/network/constants.rs
@@ -43,7 +43,7 @@
 //! ```
 
 /// Version of the protocol as appearing in network message headers
-pub const PROTOCOL_VERSION: u32 = 70001;
+pub const PROTOCOL_VERSION: u32 = 10000;
 /// Bitfield of services provided by this node
 pub const SERVICES: u64 = 0;
 /// User agent as it appears in the version message


### PR DESCRIPTION
For following [Tapyrus Core](https://github.com/chaintope/tapyrus-core/blob/56216b3c96233e9530fcb8673fde4e77e08882c1/src/version.h#L22).