### PR TITLE
Specify a version to publish on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ use-serde = ["hex", "serde", "bitcoin_hashes/serde", "secp256k1/serde"]
 
 [dependencies]
 bitcoin_hashes = "0.7.3"
-secp256k1 = { git = "https://github.com/rantan/rust-secp256k1", branch = "add_negate_support" }
+secp256k1 = { git = "https://github.com/rantan/rust-secp256k1", branch = "add_negate_support", version = "0.17.2"}
 rug = "1.7.0"
 
 bitcoinconsensus = { version = "0.19.0-1", optional = true }


### PR DESCRIPTION
We need to specify the version of the dependent library to publish it on crates.io 