### PR TITLE
Implement std::fmt::Display and consensus::Decodable for ColorIdentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+# 0.3.0
+
+- Support colored coin feature.
+    - Add new opcode `OP_COLOR`.
+    - Add support for new script type CP2PKH, and CP2SH.
+    - Add struct `ColorIdentifier` and enum `TokenTypes`.
+
 # 0.2.0
 
 - Support TapyrusCore v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tapyrus"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "MIT"
 homepage = "https://github.com/chaintope/rust-tapyrus/"

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -33,6 +33,7 @@ use hash_types::{ScriptHash, WScriptHash};
 use blockdata::opcodes;
 use blockdata::transaction::OutPoint;
 use consensus::{encode, Decodable, Encodable};
+use consensus::encode::serialize_hex;
 use hashes::{sha256, Hash};
 #[cfg(feature="bitcoinconsensus")] use bitcoinconsensus;
 #[cfg(feature="bitcoinconsensus")] use std::convert;
@@ -865,6 +866,12 @@ impl Encodable for ColorIdentifier {
     }
 }
 
+impl std::fmt::Display for ColorIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", serialize_hex(self))
+    }
+}
+
 /// Token types
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TokenTypes {
@@ -1178,6 +1185,14 @@ mod test {
         // op_return -> err
         let op_return = op_return.add_color(color_id.clone());
         assert!(op_return.is_err());
+    }
+
+    #[test]
+    fn serialize_color_id() {
+        let out_point = OutPoint::new(Txid::from_hex("0101010101010101010101010101010101010101010101010101010101010101").unwrap(), 1);
+        let color_id = ColorIdentifier::nft(out_point);
+
+        assert_eq!(format!("{}",color_id), "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46");
     }
 
     #[test]


### PR DESCRIPTION
This Pull request implement std::fmt::Display and consensus::Decodable traits for ColorIdentifier.
These are required to implement colored coin feature for Electrs-Tapyrus.
