### PR TITLE
Add TPC token types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+# 0.4.4
+
+- Add `TPC` token type(0x00).
+- Implement `Hash` with `#[derive(Hash)]` for `ColorIdentifier`
+
+# 0.4.3
+
+- Implement `Script::split_color`
+- Implement serialize/deserialize interface for `ColorIdentifier`
+
 # 0.3.0
 
 - Support colored coin feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tapyrus"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Kohei Taniguchi <kohei@chaintope.com>", "Hajime Yamaguchi <h_yamaguchi@chaintope.com>"]
 license = "MIT"
 homepage = "https://github.com/chaintope/rust-tapyrus/"

--- a/src/blockdata/script.rs
+++ b/src/blockdata/script.rs
@@ -830,10 +830,10 @@ impl Decodable for Script {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct ColorIdentifierPayload(sha256::Hash);
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// ColorIdentifier
 pub struct ColorIdentifier {
     /// Token type
@@ -989,7 +989,7 @@ impl std::fmt::Display for ColorIdentifier {
 }
 
 /// Token types
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TokenTypes {
     /// TPC
     None = 0x00,


### PR DESCRIPTION
Add TPC token types

See implementation of Tapyrus Core (https://github.com/chaintope/tapyrus-core/blob/master/src/coloridentifier.h#L40) and the review comment for the PR(https://github.com/chaintope/esplora-tapyrus/pull/10#pullrequestreview-597074206)