### PR TITLE
Add signature_hash xfield and 

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -40,6 +40,8 @@ use util::key::PublicKey;
 use util::signature::Signature;
 use VarInt;
 
+use crate::XFieldHash;
+
 /// A block header, which contains all the block's information except
 /// the actual transactions
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -153,6 +155,16 @@ impl XField {
             XField::AggregatePublicKey(_) => 35,
             XField::MaxBlockSize(_) => 5,
             XField::Unknown(_, _) => 0,
+        }
+    }
+
+    /// Return hash of serialized XField for signing
+    pub fn signature_hash(&self) -> XFieldHash {
+        match self {
+            XField::None => XFieldHash::from_str("").unwrap(),
+            XField::AggregatePublicKey(_) => XFieldHash::hash(&serialize(self)),
+            XField::MaxBlockSize(_) => XFieldHash::hash(&serialize(self)),
+            XField::Unknown(_, _) => XFieldHash::from_str("").unwrap(),
         }
     }
 }

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -161,7 +161,7 @@ impl XField {
     /// Return hash of serialized XField for signing
     pub fn signature_hash(&self) ->Result<XFieldHash, Error>  {
         match self {
-            XField::None => Ok(XFieldHash::from_str("").unwrap()),
+            XField::None => Err(Error::XFieldNone),
             XField::AggregatePublicKey(_) => Ok(XFieldHash::hash(&serialize(self))),
             XField::MaxBlockSize(_) => Ok(XFieldHash::hash(&serialize(self))),
             XField::Unknown(i, _) => Err(Error::UnknownXField(*i)),
@@ -645,10 +645,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn xfield_signature_hash_test_none() {
         let xfield = XField::None;
-        xfield.signature_hash();
+        let result = xfield.signature_hash();
+
+        assert!(matches!(result, Err(Error::XFieldNone)));
     }
 
     #[test]

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -30,7 +30,7 @@ use std::str::FromStr;
 
 use hashes::{Hash, HashEngine};
 use hashes::hex::FromHex;
-use hash_types::{Wtxid, BlockHash, BlockSigHash, TxMerkleNode, WitnessMerkleNode, WitnessCommitment};
+use hash_types::{Wtxid, BlockHash, BlockSigHash, TxMerkleNode, WitnessMerkleNode, WitnessCommitment, XFieldHash};
 use consensus::{serialize, encode, Decodable, Encodable};
 use consensus::encode::serialize_hex;
 use blockdata::constants::WITNESS_SCALE_FACTOR;
@@ -40,7 +40,6 @@ use util::key::PublicKey;
 use util::signature::Signature;
 use VarInt;
 
-use crate::XFieldHash;
 
 /// A block header, which contains all the block's information except
 /// the actual transactions
@@ -402,7 +401,7 @@ mod tests {
     use blockdata::block::{Block, XField};
     use consensus::encode::{deserialize, serialize};
     use util::key::PublicKey;
-    use hash_types::BlockSigHash;
+    use hash_types::{BlockSigHash, XFieldHash};
     use hashes::hex::FromHex;
 
     #[test]
@@ -614,5 +613,47 @@ mod tests {
         let decode: Result<Block, _> = deserialize(&block);
         assert!(decode.is_ok());
         assert_eq!(decode.unwrap().header.signature_hash(), BlockSigHash::from_hex("3d856f50e0718f72bab6516c1ab020ce3390ebc97490b6d2bad4054dc7a40a93").unwrap());
+    }
+
+    #[test]
+    fn xfield_signature_hash_test_aggpubkey() {
+        let xfield = XField::AggregatePublicKey(PublicKey::from_str("02459adb8a8f052be94874aef7d4c3d3ddb71fcdaa869b1d515a92d63cb29c2806").unwrap());
+        assert_eq!(serialize(&xfield), Vec::<u8>::from_hex("012102459adb8a8f052be94874aef7d4c3d3ddb71fcdaa869b1d515a92d63cb29c2806").unwrap());
+        assert_eq!(xfield.signature_hash(), XFieldHash::from_hex("5eb6038f90ec3b530ebed8789afd4f3f49af83fa4b00f34238c93ce0327ff9ad").unwrap());
+    }
+
+    #[test]
+    fn xfield_signature_hash_test_maxblocksize() {
+        let xfield = XField::MaxBlockSize(200000);
+        assert_eq!(serialize(&xfield), Vec::<u8>::from_hex("02400d0300").unwrap());
+        assert_eq!(xfield.signature_hash(), XFieldHash::from_hex("b2a51fb82acc2125508f323fa9567340c32257997dfd4af4e70788031d5b1915").unwrap());
+    }
+
+    #[test]
+    fn xfield_signature_hash_test_aggpubkey1() {
+        let xfield = XField::AggregatePublicKey(PublicKey::from_str("0376c3265e7d81839c1b2312b95697d47cc5b3ab3369a92a5af52ef1c945792f50").unwrap());
+        assert_eq!(serialize(&xfield), Vec::<u8>::from_hex("01210376c3265e7d81839c1b2312b95697d47cc5b3ab3369a92a5af52ef1c945792f50").unwrap());
+        assert_eq!(xfield.signature_hash(), XFieldHash::from_hex("e70d5478d63e19ab2d9aa059340785b810f82cc288e83752e726a0f9817fcc88").unwrap());
+    }
+
+    #[test]
+    fn xfield_signature_hash_test_maxblocksize1() {
+        let xfield = XField::MaxBlockSize(400000);
+        assert_eq!(serialize(&xfield), Vec::<u8>::from_hex("02801a0600").unwrap());
+        assert_eq!(xfield.signature_hash(), XFieldHash::from_hex("7b5a43d2dae273d564ec0db616efe75a31725707fc3865124e3477684f5faec0").unwrap());
+    }
+
+    #[test]
+    #[should_panic]
+    fn xfield_signature_hash_test_none() {
+        let xfield = XField::None;
+        xfield.signature_hash();
+    }
+
+    #[test]
+    #[should_panic]
+    fn xfield_signature_hash_test_unknown() {
+        let xfield = XField::Unknown{0:3, 1:Vec::<u8>::from_hex("0x12345").unwrap()};
+        xfield.signature_hash();
     }
 }

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -400,7 +400,7 @@ mod tests {
     use std::str::FromStr;
 
     use blockdata::block::{Block, XField};
-    use consensus::encode::{deserialize, serialize};
+    use consensus::encode::{deserialize, serialize, Error};
     use util::key::PublicKey;
     use hash_types::{BlockSigHash, XFieldHash};
     use hashes::hex::FromHex;
@@ -652,9 +652,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn xfield_signature_hash_test_unknown() {
-        let xfield = XField::Unknown{0:3, 1:Vec::<u8>::from_hex("0x12345").unwrap()};
-        xfield.signature_hash();
+        let xfield = XField::Unknown{0:3, 1:Vec::<u8>::from_hex("012345").unwrap()};
+        let result = xfield.signature_hash();
+        
+        assert!(matches!(result, Err(Error::UnknownXField(3))));
     }
 }

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -88,6 +88,8 @@ pub enum Error {
     UnrecognizedNetworkCommand(String),
     /// Invalid Inventory type
     UnknownInventoryType(u32),
+    /// Invalid Xfield
+    UnknownXField(u8),
 }
 
 impl fmt::Display for Error {
@@ -110,6 +112,7 @@ impl fmt::Display for Error {
             Error::UnrecognizedNetworkCommand(ref nwcmd) => write!(f,
                 "unrecognized network command: {}", nwcmd),
             Error::UnknownInventoryType(ref tp) => write!(f, "Unknown Inventory type: {}", tp),
+            Error::UnknownXField(ref tp) => write!(f, "Unknown Xfield. Xfield type: {}", tp)
         }
     }
 }
@@ -129,7 +132,8 @@ impl error::Error for Error {
             | Error::ParseFailed(..)
             | Error::UnsupportedSegwitFlag(..)
             | Error::UnrecognizedNetworkCommand(..)
-            | Error::UnknownInventoryType(..) => None,
+            | Error::UnknownInventoryType(..)
+            | Error::UnknownXField(_)=> None,
         }
     }
 

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -90,6 +90,8 @@ pub enum Error {
     UnknownInventoryType(u32),
     /// Invalid Xfield
     UnknownXField(u8),
+    /// XField was None which is unexpected as a hash
+    XFieldNone,
 }
 
 impl fmt::Display for Error {
@@ -112,7 +114,8 @@ impl fmt::Display for Error {
             Error::UnrecognizedNetworkCommand(ref nwcmd) => write!(f,
                 "unrecognized network command: {}", nwcmd),
             Error::UnknownInventoryType(ref tp) => write!(f, "Unknown Inventory type: {}", tp),
-            Error::UnknownXField(ref tp) => write!(f, "Unknown Xfield. Xfield type: {}", tp)
+            Error::UnknownXField(ref tp) => write!(f, "Unknown Xfield. Xfield type: {}", tp),
+            Error::XFieldNone => write!(f, "Xfield type None cannot be hashed or signed"),
         }
     }
 }
@@ -133,7 +136,8 @@ impl error::Error for Error {
             | Error::UnsupportedSegwitFlag(..)
             | Error::UnrecognizedNetworkCommand(..)
             | Error::UnknownInventoryType(..)
-            | Error::UnknownXField(_)=> None,
+            | Error::UnknownXField(_)
+            | Error::XFieldNone => None,
         }
     }
 

--- a/src/hash_types.rs
+++ b/src/hash_types.rs
@@ -41,6 +41,7 @@ hash_newtype!(Txid, sha256d::Hash, 32, doc="A bitcoin transaction hash/transacti
 hash_newtype!(Wtxid, sha256d::Hash, 32, doc="A bitcoin witness transaction ID.");
 hash_newtype!(BlockHash, sha256d::Hash, 32, doc="A bitcoin block hash.");
 hash_newtype!(BlockSigHash, sha256d::Hash, 32, doc="Hash of the block for sigining.");
+hash_newtype!(XFieldHash, sha256d::Hash, 32, doc="Hash of the xfield for signing");
 hash_newtype!(SigHash, sha256d::Hash, 32, doc="Hash of the transaction according to the signature algorithm");
 
 hash_newtype!(PubkeyHash, hash160::Hash, 20, doc="A hash of a public key.");
@@ -61,6 +62,7 @@ impl_hashencode!(Wtxid);
 impl_hashencode!(SigHash);
 impl_hashencode!(BlockHash);
 impl_hashencode!(BlockSigHash);
+impl_hashencode!(XFieldHash);
 impl_hashencode!(TxMerkleNode);
 impl_hashencode!(WitnessMerkleNode);
 impl_hashencode!(FilterHash);


### PR DESCRIPTION
Add a new hash type called XfieldHash to get the hash of serialised xfield. This is used during tapyrus-signer setup to generate a threshold signature for new xfield changes. 